### PR TITLE
Wrap errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ go.work
 
 # Visual Studio Code
 .vscode/
+
+# Temporary test data
+testdata/*/unreadable-file.sql

--- a/sqload.go
+++ b/sqload.go
@@ -4,6 +4,7 @@
 // Its usage is very straightforward; let's suppose you have the following SQL file:
 //
 // File queries.sql:
+//
 //	-- query: FindUserById
 //	-- Finds a user by its id.
 //	SELECT first_name,
@@ -22,9 +23,11 @@
 //	-- Deletes a user by its id.
 //	DELETE FROM user
 //	      WHERE id = :id;
+//
 // You could load the SQL code of those queries into strings using the following:
 //
 // File main.go:
+//
 //	package main
 //
 //	import (
@@ -48,10 +51,14 @@
 //		fmt.Printf("- UpdateFirstNameById\n%s\n\n", Q.UpdateFirstNameById)
 //		fmt.Printf("- DeleteUserById\n%s\n\n", Q.DeleteUserById)
 //	}
+//
 // The module maps the fields of your struct and the queries from the SQL file using the
 // query tag (in the struct):
+//
 //	`query:"NameOfYourQuery"`
+//
 // And the query comment (in the SQL code):
+//
 //	-- query: NameOfYourQuery
 package sqload
 
@@ -207,6 +214,7 @@ func cat(fsys fs.FS, filenames []string) (string, error) {
 //
 // If some query has an invalid name in the string or is not found in the string, it
 // will return a nil pointer and an error.
+//
 //	package main
 //
 //	import (
@@ -281,6 +289,7 @@ func MustLoadFromString[V Struct](s string) *V {
 // error.
 //
 // File queries.sql:
+//
 //	-- query: FindUserById
 //	SELECT first_name,
 //	       last_name,
@@ -299,6 +308,7 @@ func MustLoadFromString[V Struct](s string) *V {
 //	      WHERE id = :id;
 //
 // File main.go:
+//
 //	package main
 //
 //	import (
@@ -354,19 +364,26 @@ func MustLoadFromFile[V Struct](filename string) *V {
 // If any .sql file can not be read, it will return a nil pointer and an error.
 //
 // Project directory:
+//
 //	.
 //	├── go.mod
 //	├── main.go
 //	└── sql
 //	    ├── cats.sql
 //	    └── users.sql
+//
 // File sql/cats.sql:
+//
 //	-- query: CreatePsychoCat
 //	INSERT INTO Cat (name, color) VALUES ('Puca', 'Orange');
+//
 // File sql/users.sql:
+//
 //	-- query: DeleteUserById
 //	DELETE FROM user WHERE id = :id;
+//
 // File main.go:
+//
 //	package main
 //
 //	import (
@@ -425,19 +442,26 @@ func MustLoadFromDir[V Struct](dirname string) *V {
 // If any .sql file can not be read, it will return a nil pointer and an error.
 //
 // Project directory:
+//
 //	.
 //	├── go.mod
 //	├── main.go
 //	└── sql
 //	    ├── cats.sql
 //	    └── users.sql
+//
 // File sql/cats.sql:
+//
 //	-- query: CreatePsychoCat
 //	INSERT INTO Cat (name, color) VALUES ('Puca', 'Orange');
+//
 // File sql/users.sql:
+//
 //	-- query: DeleteUserById
 //	DELETE FROM user WHERE id = :id;
+//
 // File main.go:
+//
 //	package main
 //
 //	import (

--- a/sqload_test.go
+++ b/sqload_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -549,24 +550,28 @@ func TestLoadFromDir(t *testing.T) {
 	if err == nil {
 		t.Fatalf("dir testdata/i-dont-exist must not exists so this test can fail")
 	}
-	// Test that the function fails when it can not read some .sql file
-	unreadableFilename := "testdata/test-load-from-dir/unreadable-file.sql"
-	unreadableFile, err := os.Create(unreadableFilename)
-	if err != nil {
-		t.Fatalf("unable to create %s: %s", unreadableFilename, err)
-	}
-	defer unreadableFile.Close()
-	err = os.Chmod(unreadableFilename, 0222)
-	if err != nil {
-		t.Fatalf("unable to set the permissions of %s to 0222: %s", unreadableFilename, err)
-	}
-	_, err = LoadFromDir[RandomQuery]("testdata/test-load-from-dir")
-	if err == nil {
-		t.Fatal("error is nil")
-	}
-	err = os.Remove(unreadableFilename)
-	if err != nil {
-		t.Fatalf("unable to remove %s: %s", unreadableFilename, err)
+
+	// Permission-based tests do not work on Windows
+	if runtime.GOOS != "windows" {
+		// Test that the function fails when it can not read some .sql file
+		unreadableFilename := "testdata/test-load-from-dir/unreadable-file.sql"
+		unreadableFile, err := os.Create(unreadableFilename)
+		if err != nil {
+			t.Fatalf("unable to create %s: %s", unreadableFilename, err)
+		}
+		defer unreadableFile.Close()
+		err = os.Chmod(unreadableFilename, 0222)
+		if err != nil {
+			t.Fatalf("unable to set the permissions of %s to 0222: %s", unreadableFilename, err)
+		}
+		_, err = LoadFromDir[RandomQuery]("testdata/test-load-from-dir")
+		if err == nil {
+			t.Fatal("error is nil")
+		}
+		err = os.Remove(unreadableFilename)
+		if err != nil {
+			t.Fatalf("unable to remove %s: %s", unreadableFilename, err)
+		}
 	}
 	// Test that the function succeeds when using the happy path
 	queries, err := LoadFromDir[RandomQuery]("testdata/test-load-from-dir")
@@ -630,25 +635,28 @@ func TestLoadFromFS(t *testing.T) {
 	if err == nil {
 		t.Fatalf("dir testdata/i-dont-exist must not exists so this test can fail")
 	}
-	// Test that the function fails when it can not read some .sql file
-	unreadableFilename := "testdata/test-load-from-fs/unreadable-file.sql"
-	unreadableFile, err := os.Create(unreadableFilename)
-	if err != nil {
-		t.Fatalf("unable to create %s: %s", unreadableFilename, err)
-	}
-	defer unreadableFile.Close()
-	err = os.Chmod(unreadableFilename, 0222)
-	if err != nil {
-		t.Fatalf("unable to set the permissions of %s to 0222: %s", unreadableFilename, err)
-	}
-	fsys = os.DirFS("testdata/test-load-from-fs")
-	_, err = LoadFromFS[RandomQuery](fsys)
-	if err == nil {
-		t.Fatal("error is nil")
-	}
-	err = os.Remove(unreadableFilename)
-	if err != nil {
-		t.Fatalf("unable to remove %s: %s", unreadableFilename, err)
+	// Permission-based tests do not work on Windows
+	if runtime.GOOS != "windows" {
+		// Test that the function fails when it can not read some .sql file
+		unreadableFilename := "testdata/test-load-from-fs/unreadable-file.sql"
+		unreadableFile, err := os.Create(unreadableFilename)
+		if err != nil {
+			t.Fatalf("unable to create %s: %s", unreadableFilename, err)
+		}
+		defer unreadableFile.Close()
+		err = os.Chmod(unreadableFilename, 0222)
+		if err != nil {
+			t.Fatalf("unable to set the permissions of %s to 0222: %s", unreadableFilename, err)
+		}
+		fsys = os.DirFS("testdata/test-load-from-fs")
+		_, err = LoadFromFS[RandomQuery](fsys)
+		if err == nil {
+			t.Fatal("error is nil")
+		}
+		err = os.Remove(unreadableFilename)
+		if err != nil {
+			t.Fatalf("unable to remove %s: %s", unreadableFilename, err)
+		}
 	}
 	// Test that the function succeeds when using the happy path
 	fsys = os.DirFS("testdata/test-load-from-fs")


### PR DESCRIPTION
For many years, Go has recommended "wrapping" errors with additional context.

This Pull Request implements such wrapping, with a global base error `sqload.ErrCannotLoadQueries`, so callers can check `if errors.Is(err, sqload.ErrCannotLoadQueries) to handle errors that are specific to this package.