### PR TITLE
Feature: load a file as single query

### DIFF
--- a/sqload.go
+++ b/sqload.go
@@ -415,15 +415,7 @@ func MustLoadFromFile[V Struct](filename string) *V {
 //	}
 func LoadFromDir[V Struct](dirname string) (*V, error) {
 	fsys := os.DirFS(dirname)
-	files, err := findFilesWithExt(fsys, ".sql")
-	if err != nil {
-		return nil, err
-	}
-	sql, err := cat(fsys, files)
-	if err != nil {
-		return nil, err
-	}
-	return LoadFromString[V](sql)
+	return LoadFromFS[V](fsys)
 }
 
 // MustLoadFromDir is like LoadFromDir but panics if any error occurs. It simplifies the
@@ -500,6 +492,14 @@ func LoadFromFS[V Struct](fsys fs.FS) (*V, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	for _, filename := range files {
+		data, err := fs.ReadFile(fsys, filename)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	sql, err := cat(fsys, files)
 	if err != nil {
 		return nil, err

--- a/sqload.go
+++ b/sqload.go
@@ -542,14 +542,12 @@ func LoadFromFS[V Struct](fsys fs.FS) (*V, error) {
 	for _, filename := range files {
 		data, err := fs.ReadFile(fsys, filename)
 		if err != nil {
-			// TODO: Wrap once PR#12 is merged
-			return nil, err
+			return nil, fmt.Errorf("%w: %s", ErrCannotLoadQueries, err)
 		}
 
 		fileQueries, err := ExtractQueryMap(string(data))
 		if err != nil {
-			// TODO: Wrap once PR#12 is merged
-			return nil, err
+			return nil, fmt.Errorf("%w: %s", ErrCannotLoadQueries, err)
 		}
 
 		// If the file does not have "query" tags,

--- a/sqload.go
+++ b/sqload.go
@@ -321,7 +321,7 @@ func MustLoadFromString[V Struct](s string) *V {
 // If some query has an invalid name in the string or is not found in the string, it
 // will return a nil pointer and an error.
 //
-// If the file can not be read or does not exist, it will return a nil pointer and an
+// If the file cannot be read or does not exist, it will return a nil pointer and an
 // error.
 //
 // File queries.sql:
@@ -391,13 +391,16 @@ func MustLoadFromFile[V Struct](filename string) *V {
 // (recursively) and returns a pointer to a struct. Each struct field will contain the
 // SQL query code it was tagged with.
 //
+// If a .sql file in the directory does not contain any tagged queries, the entire file
+// will be assumed to be a single query, and will use the filename as its tag.
+//
 // If some query has an invalid name in the string or is not found in the string, it
 // will return a nil pointer and an error.
 //
-// If the directory can not be read or does not exist, it will return a nil pointer and
+// If the directory cannot be read or does not exist, it will return a nil pointer and
 // an error.
 //
-// If any .sql file can not be read, it will return a nil pointer and an error.
+// If any .sql file cannot be read, it will return a nil pointer and an error.
 //
 // Project directory:
 //
@@ -405,8 +408,13 @@ func MustLoadFromFile[V Struct](filename string) *V {
 //	├── go.mod
 //	├── main.go
 //	└── sql
+//	    ├── cars.sql
 //	    ├── cats.sql
 //	    └── users.sql
+//
+// File sql/cars.sql:
+//
+//	SELECT * FROM cars;
 //
 // File sql/cats.sql:
 //
@@ -433,6 +441,7 @@ func MustLoadFromFile[V Struct](filename string) *V {
 //		q, err := sqload.LoadFromDir[struct {
 //			CreatePsychoCat string `query:"CreatePsychoCat"`
 //			DeleteUserById  string `query:"DeleteUserById"`
+//			ListsAllCars    string `query:"sql/cars.sql"`
 //		}]("sql")
 //		if err != nil {
 //			fmt.Printf("Unable to load SQL queries: %s\n", err)
@@ -440,6 +449,7 @@ func MustLoadFromFile[V Struct](filename string) *V {
 //		}
 //		fmt.Printf("- CreatePsychoCat\n%s\n\n", q.CreatePsychoCat)
 //		fmt.Printf("- DeleteUserById\n%s\n\n", q.DeleteUserById)
+//		fmt.Printf("- ListAllCars\n%s\n\n", q.ListAllCars)
 //	}
 func LoadFromDir[V Struct](dirname string) (*V, error) {
 	fsys := os.DirFS(dirname)
@@ -461,13 +471,16 @@ func MustLoadFromDir[V Struct](dirname string) *V {
 // (recursively) and returns a pointer to a struct. Each struct field will contain the
 // SQL query code it was tagged with.
 //
+// If a .sql file in the file system does not contain any tagged queries, the entire file
+// will be assumed to be a single query, and will use the filename as its tag.
+//
 // If some query has an invalid name in the string or is not found in the string, it
 // will return a nil pointer and an error.
 //
-// If the fsys can not be read or does not exist, it will return a nil pointer and
+// If the fsys cannot be read or does not exist, it will return a nil pointer and
 // an error.
 //
-// If any .sql file can not be read, it will return a nil pointer and an error.
+// If any .sql file cannot be read, it will return a nil pointer and an error.
 //
 // Project directory:
 //
@@ -475,8 +488,13 @@ func MustLoadFromDir[V Struct](dirname string) *V {
 //	├── go.mod
 //	├── main.go
 //	└── sql
+//	    ├── cars.sql
 //	    ├── cats.sql
 //	    └── users.sql
+//
+// File sql/cars.sql:
+//
+//	SELECT * FROM cars;
 //
 // File sql/cats.sql:
 //
@@ -507,6 +525,7 @@ func MustLoadFromDir[V Struct](dirname string) *V {
 //		q, err := sqload.LoadFromFS[struct {
 //			CreatePsychoCat string `query:"CreatePsychoCat"`
 //			DeleteUserById  string `query:"DeleteUserById"`
+//			ListsAllCars    string `query:"sql/cars.sql"`
 //		}](fsys)
 //		if err != nil {
 //			fmt.Printf("Unable to load SQL queries: %s\n", err)
@@ -514,6 +533,7 @@ func MustLoadFromDir[V Struct](dirname string) *V {
 //		}
 //		fmt.Printf("- CreatePsychoCat\n%s\n\n", q.CreatePsychoCat)
 //		fmt.Printf("- DeleteUserById\n%s\n\n", q.DeleteUserById)
+//		fmt.Printf("- ListAllCars\n%s\n\n", q.ListAllCars)
 //	}
 func LoadFromFS[V Struct](fsys fs.FS) (*V, error) {
 	files, err := findFilesWithExt(fsys, ".sql")

--- a/sqload.go
+++ b/sqload.go
@@ -200,9 +200,6 @@ func loadQueriesIntoStruct(queries map[string]string, v Struct, allowPartial boo
 			return fmt.Errorf("%w: field %s cannot be changed or is not a string", ErrCannotLoadQueries, elem.Type().Field(fieldIndex).Name)
 		}
 		if ok {
-			if field.String() != "" {
-				return fmt.Errorf("duplicate query for field %s", elem.Type().Field(fieldIndex).Name)
-			}
 			field.SetString(sql)
 		}
 	}

--- a/sqload_test.go
+++ b/sqload_test.go
@@ -343,7 +343,7 @@ func TestLoadQueriesIntoStruct(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("%d (v=%v)", i, testCase.v), func(t *testing.T) {
-			err := loadQueriesIntoStruct(map[string]string{}, testCase.v)
+			err := loadQueriesIntoStruct(map[string]string{}, testCase.v, false)
 			if fmt.Sprint(err) != fmt.Sprint(testCase.err) {
 				t.Errorf("got %s, want %s", err, testCase.err)
 				return
@@ -355,7 +355,7 @@ func TestLoadQueriesIntoStruct(t *testing.T) {
 		CreateCatTable int `query:"CreateCatTable"`
 	}
 	invalidCatQuery := InvalidCatQuery{}
-	err := loadQueriesIntoStruct(CatTestQueries, &invalidCatQuery)
+	err := loadQueriesIntoStruct(CatTestQueries, &invalidCatQuery, false)
 	wantedErr := fmt.Errorf("%w: field %s cannot be changed or is not a string", ErrCannotLoadQueries, "CreateCatTable")
 	if fmt.Sprint(err) != fmt.Sprint(wantedErr) {
 		t.Errorf("got %s, want %s", err, wantedErr)
@@ -365,7 +365,7 @@ func TestLoadQueriesIntoStruct(t *testing.T) {
 		DeleteCatById int `query:"DeleteCatById"`
 	}
 	missingCatQueries := MissingCatQueries{}
-	err = loadQueriesIntoStruct(CatTestQueries, &missingCatQueries)
+	err = loadQueriesIntoStruct(CatTestQueries, &missingCatQueries, false)
 	wantedErr = fmt.Errorf("%w: could not find query %s", ErrCannotLoadQueries, "DeleteCatById")
 	if fmt.Sprint(err) != fmt.Sprint(wantedErr) {
 		t.Errorf("got %s, want %s", err, wantedErr)
@@ -378,7 +378,7 @@ func TestLoadQueriesIntoStruct(t *testing.T) {
 		UpdateColorById string `query:"UpdateColorById"`
 	}
 	catQuery := CatQuery{}
-	err = loadQueriesIntoStruct(CatTestQueries, &catQuery)
+	err = loadQueriesIntoStruct(CatTestQueries, &catQuery, false)
 	if err != nil {
 		t.Fatalf("err must be nil, got %s", err)
 	}

--- a/sqload_test.go
+++ b/sqload_test.go
@@ -544,6 +544,7 @@ func TestLoadFromDir(t *testing.T) {
 		UpdateFirstNameById string `query:"UpdateFirstNameById"`
 		DeleteUserById      string `query:"DeleteUserById"`
 		FindRiders          string `query:"FindRiders"`
+		ListAllCars         string `query:"big-single-query.sql"`
 	}
 	// Test that the function fails when the directory does not exist
 	_, err := LoadFromDir[RandomQuery]("testdata/i-dont-exist")
@@ -628,6 +629,7 @@ func TestLoadFromFS(t *testing.T) {
 		UpdateFirstNameById string `query:"UpdateFirstNameById"`
 		DeleteUserById      string `query:"DeleteUserById"`
 		FindRiders          string `query:"FindRiders"`
+		ListAllCars         string `query:"big-single-query.sql"`
 	}
 	// Test that the function fails when the directory does not exist
 	fsys := os.DirFS("testdata/i-dont-exist")

--- a/testdata/test-load-from-dir/big-single-query.sql
+++ b/testdata/test-load-from-dir/big-single-query.sql
@@ -1,0 +1,3 @@
+-- This file has a single query in it.
+-- This can be used for very large standalone queries
+SELECT * FROM cars;

--- a/testdata/test-load-from-fs/big-single-query.sql
+++ b/testdata/test-load-from-fs/big-single-query.sql
@@ -1,0 +1,3 @@
+-- This file has a single query in it.
+-- This can be used for very large standalone queries
+SELECT * FROM cars;


### PR DESCRIPTION
The [Yesql](https://github.com/krisajenkins/yesql/) project that inspired this project has a feature that this project is currently missing.

Specifically, storing a single query in a file, and referencing the filename instead of needing a "magic" comment to identify the query.

This feature is particularly useful for complex queries, such as those containing many Common Table Expressions and/or subqueries.

This PR adds support for that feature, including adding examples to the documentation.

---

In the process, this PR also fixes a bug in the previous implementation that would happen if a `.sql` file was present without any magic comments. Because all the `.sql` files were concatenated into one long string, the entire contents of the file that was missing comments would be included in the previous query.